### PR TITLE
Fix waveform rendering when sample data doesn't end with 0

### DIFF
--- a/WaveformTimeline/Controls/Waveform/WaveformRenderingProgress.cs
+++ b/WaveformTimeline/Controls/Waveform/WaveformRenderingProgress.cs
@@ -13,9 +13,11 @@ namespace WaveformTimeline.Controls.Waveform
         {
             _leftWaveformPolyLine = leftWaveformPolyLine;
             _rightWaveformPolyLine = rightWaveformPolyLine;
-            _pointThickness = waveformDimensions.Width() / (int)((waveformSection.End - waveformSection.Start) / 2.0d);
+            _pointThickness = waveformDimensions.Width() / (int)((waveformSection.End - waveformSection.Start + 1) / 2.0d);
             _height = mainCanvas.RenderSize.Height / 2.0d;
             _leftMargin = waveformDimensions.LeftMargin();
+            _leftWaveformPolyLine.Points.Add(new Point(_xLocation, _height));
+            _rightWaveformPolyLine.Points.Add(new Point(_xLocation, _height));
         }
 
         private readonly PolyLineSegment _leftWaveformPolyLine;
@@ -28,6 +30,8 @@ namespace WaveformTimeline.Controls.Waveform
 
         public void DrawWaveform(float[] wf)
         {
+            _rightWaveformPolyLine.Points.RemoveAt(_rightWaveformPolyLine.Points.Count - 1);
+            _leftWaveformPolyLine.Points.RemoveAt(_leftWaveformPolyLine.Points.Count - 1);
             var pointsDrawn = _pointsDrawn;
             var location = _xLocation;
             for (var i = 0; i < wf.Length; i += 2)
@@ -38,6 +42,11 @@ namespace WaveformTimeline.Controls.Waveform
                 pointsDrawn += 2;
             }
             (_xLocation, _pointsDrawn) = (location, pointsDrawn);
+            // Add a point at y=0 to ensure that the resulting polygon is is flush with the middle line
+            // This makes the progressive animation look nicer besides fixing the rendering of some files
+            // It could also just happen once in CompleteWaveform(), but then the animation fix wouldn't be kept
+            _rightWaveformPolyLine.Points.Add(new Point(_xLocation, _height));
+            _leftWaveformPolyLine.Points.Add(new Point(_xLocation, _height));
         }
 
         public void CompleteWaveform()


### PR DESCRIPTION
## Current behavior

When rendering a waveform with progressive rendering enabled, this is what currently happens: https://webmshare.com/play/3K3Ln

I assume this could be intended, because it doesn't necessarily look bad and shows the progress perhaps more readily than the proposed solution.
But there is a problem in that some files don't seem to end on a 0, and the artifact remains visible even once the progressive animation completes:

![f7tzPLee30](https://user-images.githubusercontent.com/6323641/230247763-f83140e2-a2dd-49af-832a-c628a106341b.png)

This is especially evident at low resolutions. The above image was taken at 80 (I tested up to 200, then 8000) but it's been consistent at higher resolutions too, depending on the file.

## Proposed solution

The fix is to add a point at y=0 at the end of the polyline representing the waveform. This can be done in two places:

- In `CompleteWaveform()`, before the polylines are frozen. This doesn't solve the animation problem, but it's a very simple fix.
- In `DrawWaveform()` each time some data comes in. This requires removing the last point when the method is called, and re-adding it at the end.

For this PR I went with the second, more thorough, option. I also made sure to update the `_pointThickness` calculation to account for the single extra point introduced by this change.

This is what the above waveforms look like now: https://webmshare.com/play/o1z3n

![w2zJqxvFt1](https://user-images.githubusercontent.com/6323641/230248834-d7d11d97-a316-4e4b-8632-8a955c1ef2c8.png)
